### PR TITLE
add require 'c_system_common.php'; inline 8

### DIFF
--- a/zb_system/function/c_system_misc.php
+++ b/zb_system/function/c_system_misc.php
@@ -5,6 +5,7 @@
  * @subpackage System\Misc 摘取信息
  * @copyright (C) RainbowSoft Studio
  */
+require 'c_system_common.php'；
 
 ob_clean();
 


### PR DESCRIPTION
在 c_system_misc.php 文件里 使用了 GetVars 函数
GetVars函数是定义在 c_system_common.php 文件里的
c_system_misc.php文件并没有调用 c_system_common.php 文件 导致 访问c_system_misc.php    时出错