### PR TITLE
关闭网站时返回503状态码

### DIFF
--- a/zb_system/function/lib/zblogphp.php
+++ b/zb_system/function/lib/zblogphp.php
@@ -3126,6 +3126,7 @@ class ZBlogPHP
     public function CheckSiteClosed()
     {
         if ($this->option['ZC_CLOSE_SITE']) {
+            Http503();
             $this->ShowError(82, __FILE__, __LINE__);
             exit;
         }


### PR DESCRIPTION
增加关闭网站时响应Http503()，利于SEO友好
ZC_CLOSE_SITE，ZC_CLOSE_WHOLE_SITE 有点分不清