### PR TITLE
列表用户预加载到 $zbp->members

### DIFF
--- a/zb_system/function/c_system_event.php
+++ b/zb_system/function/c_system_event.php
@@ -1100,6 +1100,9 @@ function ViewList($page, $cate, $auth, $date, $tags, $isrewrite = false)
         $zbp->ShowError(2, __FILE__, __LINE__);
     }
 
+    $zbp->LoadMembersInList($articles_top);
+    $zbp->LoadMembersInList($articles);
+
     $zbp->template->SetTags('title', $zbp->title);
     $zbp->template->SetTags('articles', array_merge($articles_top, $articles));
     if ($pagebar->PageAll == 0) {
@@ -1279,6 +1282,8 @@ function ViewPost($object, $theSecondParam, $enableRewrite = false)
             $comment->Content = FormatString($comment->Content, '[enter]') . '<label id="AjaxComment' . $comment->ID . '"></label>';
         }
     }
+
+    $zbp->LoadMembersInList($comments);
 
     $zbp->template->SetTags('title', ($article->Status == 0 ? '' : '[' . $zbp->lang['post_status_name'][$article->Status] . ']') . $article->Title);
     $zbp->template->SetTags('article', $article);

--- a/zb_system/function/lib/zblogphp.php
+++ b/zb_system/function/lib/zblogphp.php
@@ -1430,6 +1430,45 @@ class ZBlogPHP
         return true;
     }
 
+    /**
+     * 通过列表（文章/评论）一次性将用户预载入到 members 里.
+     *
+     * @param array $list 文章/评论列表数组
+     *
+     * @return boolean
+     */
+    public function LoadMembersInList($list)
+    {
+        $mem_ids_need_load = array();
+        
+        foreach ($list as $obj) {
+            if (!isset($obj->AuthorID) || ((int) $obj->AuthorID <= 0)) {
+                continue;
+            }
+
+            // 已经载入的用户不重新载入
+            if (isset($this->members[$obj->AuthorID])) {
+                continue;
+            }
+
+            $mem_ids_need_load[] = $obj->AuthorID;
+        }
+
+        if (count($mem_ids_need_load) === 0) {
+            return true;
+        }
+
+        $array = $this->GetMemberList(null, array(
+            array('IN', 'mem_ID', $mem_ids_need_load)
+        ));
+        foreach ($array as $m) {
+            $this->members[$m->ID] = $m;
+            $this->membersbyname[$m->Name] = &$this->members[$m->ID];
+        }
+
+        return true;
+    }
+
     private function LoadCategories_Recursion($deep, $id, &$lv)
     {
         $subarray = array();


### PR DESCRIPTION
当默认不再载入所有用户时，文章或评论列表页可能需要查询多次用户。增加 $zbp->LoadMembersInList() 便于在列表查询后预先通过 SQL WHERE IN 将当前列表的所有用户载入到 members 数组，类似 Laravel 模型关联预加载，降低查询次数。