### PR TITLE
修正模块名称导致无法拖到侧边栏的问题

### DIFF
--- a/zb_system/function/c_system_admin.php
+++ b/zb_system/function/c_system_admin.php
@@ -1394,7 +1394,16 @@ function Admin_ModuleMng()
                 start: function(event, ui) {
                     showWidget(ui.item.parent().prev());
                     var c = ui.item.find(".funid").html();
-                    if (ui.item.parent().find(".widget:contains(" + c + ")[innerHTML=" + c + "]").length > 1) {
+                    var siderbarName = [];
+                    ui.item.parent().find(".funid").each(function(item, element) {
+                        var c = $(element).html();
+                        if (siderbarName[c] !== undefined) {
+                            siderbarName[c] += 1
+                        } else {
+                            siderbarName[c] = 1
+                        }
+                    })
+                    if (siderbarName[c] > 1) {
                         ui.item.remove();
                     };
                 },

--- a/zb_system/function/c_system_admin.php
+++ b/zb_system/function/c_system_admin.php
@@ -1394,7 +1394,7 @@ function Admin_ModuleMng()
                 start: function(event, ui) {
                     showWidget(ui.item.parent().prev());
                     var c = ui.item.find(".funid").html();
-                    if (ui.item.parent().find(".widget:contains(" + c + ")").length > 1) {
+                    if (ui.item.parent().find(".widget:contains(" + c + ")[innerHTML=" + c + "]").length > 1) {
                         ui.item.remove();
                     };
                 },


### PR DESCRIPTION
contains只会模糊匹配
例如侧栏已存在模块名demo_aaa_001，此时无法将模块名demo_aaa给拖进来