### PR TITLE
更改用户组下拉菜单逻辑

### DIFF
--- a/zb_system/function/c_system_admin_function.php
+++ b/zb_system/function/c_system_admin_function.php
@@ -509,9 +509,9 @@ function OutputOptionItemsOfMemberLevel($default)
     if (!$zbp->CheckRights('MemberAll')) {
         $tz[$default] = $zbp->lang['user_level_name'][$default];
     } else {
-		foreach ($zbp->lang['user_level_name'] as $level => $levelname){
-			$tz[$level] = $levelname;			
-		}        
+        foreach ($zbp->lang['user_level_name'] as $level => $levelname){
+            $tz[$level] = $levelname;			
+        }        
     }
 
     foreach ($GLOBALS['hooks']['Filter_Plugin_OutputOptionItemsOfMemberLevel'] as $fpname => &$fpsignal) {

--- a/zb_system/function/c_system_admin_function.php
+++ b/zb_system/function/c_system_admin_function.php
@@ -509,9 +509,9 @@ function OutputOptionItemsOfMemberLevel($default)
     if (!$zbp->CheckRights('MemberAll')) {
         $tz[$default] = $zbp->lang['user_level_name'][$default];
     } else {
-        foreach ($zbp->lang['user_level_name'] as $level => $levelname){
-            $tz[$level] = $levelname;			
-        }        
+        foreach ($zbp->lang['user_level_name'] as $level => $levelname) {
+            $tz[$level] = $levelname;
+        }
     }
 
     foreach ($GLOBALS['hooks']['Filter_Plugin_OutputOptionItemsOfMemberLevel'] as $fpname => &$fpsignal) {

--- a/zb_system/function/c_system_admin_function.php
+++ b/zb_system/function/c_system_admin_function.php
@@ -509,9 +509,9 @@ function OutputOptionItemsOfMemberLevel($default)
     if (!$zbp->CheckRights('MemberAll')) {
         $tz[$default] = $zbp->lang['user_level_name'][$default];
     } else {
-        for ($i = 1; $i < (count($zbp->lang['user_level_name']) + 1); $i++) {
-            $tz[$i] = $zbp->lang['user_level_name'][$i];
-        }
+		foreach ($zbp->lang['user_level_name'] as $level => $levelname){
+			$tz[$level] = $levelname;			
+		}        
     }
 
     foreach ($GLOBALS['hooks']['Filter_Plugin_OutputOptionItemsOfMemberLevel'] as $fpname => &$fpsignal) {


### PR DESCRIPTION
更改用户组下拉菜单逻辑，以解决当$zbp->lang['user_level_name']的索引不连续时报错的问题。