### PR TITLE
[修正] $url为null时，PHP8+环境下会抛出警告，导致error堆积日志

### DIFF
--- a/zb_system/function/lib/urlrule.php
+++ b/zb_system/function/lib/urlrule.php
@@ -95,6 +95,10 @@ class UrlRule
     {
         global $zbp;
         $url = $this->GetPreUrl();
+        // 确保 $url 不是 null，兼容 PHP 8+
+        if ($url === null) {
+            $url = '';
+        }
         $route = $this->GetRoute();
 
         $only_match_page = GetValueInArray($route, 'only_match_page', false);
@@ -163,6 +167,10 @@ class UrlRule
         $prefix = ($prefix != '') ? ($prefix . '/') : $prefix;
         $this->Rules['{%host%}'] = $zbp->host . $prefix;
 
+        // 确保 $url 是字符串类型，兼容 PHP 8+
+        if ($url === null) {
+            $url = '';
+        }
         foreach ($this->Rules as $key => $value) {
             if (!is_array($value)) {
                 $url = str_replace($key, (string) $value, $url);


### PR DESCRIPTION
日志示例：
```txt
...
[2025-11-03 17:30:03 .03251900 +08:00] ERROR system 0.0.0.0
array (
  0 => 'E_DEPRECATED',
  1 => 8192,
  2 => 'strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated',
  3 => '/app/zb_system/function/lib/urlrule.php',
  4 => 124,
)
[2025-11-03 17:30:03 .03259400 +08:00] ERROR system 0.0.0.0
array (
  0 => 'E_DEPRECATED',
  1 => 8192,
  2 => 'strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated',
  3 => '/app/zb_system/function/lib/urlrule.php',
  4 => 131,
)
[2025-11-03 17:30:03 .03262700 +08:00] ERROR system 0.0.0.0
array (
  0 => 'E_DEPRECATED',
  1 => 8192,
  2 => 'str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated',
  3 => '/app/zb_system/function/lib/urlrule.php',
  4 => 168,
)
...
```