### PR TITLE
修改IP地址获取逻辑和后台展示逻辑，以解决特定情况下的持续"验证码错误"无法登陆的情况

### DIFF
--- a/zb_system/function/c_system_admin_function.php
+++ b/zb_system/function/c_system_admin_function.php
@@ -852,13 +852,24 @@ function CreateOptionsOfGuestIPType($default)
 {
     global $zbp;
     $s = '';
-    $tz = array(
-        'REMOTE_ADDR'                    => 'REMOTE_ADDR (' . $zbp->lang['msg']['default'] . ') ' . GetVars('REMOTE_ADDR', 'SERVER'),
-        'HTTP_X_FORWARDED_FOR'           => 'HTTP_X_FORWARDED_FOR (腾讯云,阿里云,七牛) ' . GetVars('HTTP_X_FORWARDED_FOR', 'SERVER'),
-        'HTTP_X_REAL_IP'                 => 'HTTP_X_REAL_IP (又拍云,百度CDN)' . GetVars('HTTP_X_REAL_IP', 'SERVER'),
-        'HTTP_CF_CONNECTING_IP'          => 'HTTP_CF_CONNECTING_IP (CloudFlare) ' . GetVars('HTTP_CF_CONNECTING_IP', 'SERVER'),
-        'HTTP_CLIENT_IP'                 => 'HTTP_CLIENT_IP ' . GetVars('HTTP_CLIENT_IP', 'SERVER'),
+    $orig = $zbp->option['ZC_USING_CDN_GUESTIP_TYPE'];
+    $headers = array(
+        'REMOTE_ADDR'                    => 'REMOTE_ADDR (' . $zbp->lang['msg']['default'] . ')',
+        'HTTP_X_FORWARDED_FOR'           => 'HTTP_X_FORWARDED_FOR (腾讯云,阿里云,七牛)',
+        'HTTP_X_REAL_IP'                 => 'HTTP_X_REAL_IP (又拍云,百度CDN)',
+        'HTTP_CF_CONNECTING_IP'          => 'HTTP_CF_CONNECTING_IP (CloudFlare)',
+        'HTTP_CLIENT_IP'                 => 'HTTP_CLIENT_IP',
     );
+    $tz = array();
+    foreach ($headers as $key => $label) {
+        if (GetVars($key, 'SERVER') === null || GetVars($key, 'SERVER') === '') {
+            $tz[$key] = $label;
+        } else {
+            $zbp->option['ZC_USING_CDN_GUESTIP_TYPE'] = $key;
+            $tz[$key] = $label . ' ' . GetGuestIP();
+        }
+    }
+    $zbp->option['ZC_USING_CDN_GUESTIP_TYPE'] = $orig;
 
     foreach ($GLOBALS['hooks']['Filter_Plugin_OutputOptionItemsOfCommon'] as $fpname => &$fpsignal) {
         $fpreturn = $fpname($default, $tz, 'GuestIPType');

--- a/zb_system/function/c_system_common.php
+++ b/zb_system/function/c_system_common.php
@@ -425,6 +425,10 @@ function GetGuestIP()
         $user_ip = GetVars("REMOTE_ADDR", "SERVER");
     } else {
         $user_ip = GetVars($zbp->option['ZC_USING_CDN_GUESTIP_TYPE'], "SERVER");
+        if (strpos($user_ip, ',') !== false) {
+            $array = explode(",", $user_ip);
+            $user_ip = trim($array[0]);
+        }
     }
 
     if (is_null($user_ip)) {
@@ -432,15 +436,20 @@ function GetGuestIP()
             $user_ip = $_SERVER["HTTP_X_FORWARDED_FOR"];
             if (strpos($user_ip, ',') !== false) {
                 $array = explode(",", $user_ip);
-                $user_ip = $array[0];
+                $user_ip = trim($array[0]);
             }
         } elseif (isset($_SERVER["HTTP_X_REAL_IP"])) {
-            $user_ip = $_SERVER["HTTP_X_REAL_IP"];
+            $user_ip = trim($_SERVER["HTTP_X_REAL_IP"]);
         } elseif (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
-            $user_ip = $_SERVER["HTTP_CF_CONNECTING_IP"];
+            $user_ip = trim($_SERVER["HTTP_CF_CONNECTING_IP"]);
         } else {
             $user_ip = GetVars("REMOTE_ADDR", "SERVER");
         }
+    }
+
+    $user_ip = trim($user_ip);
+    if (!filter_var($user_ip, FILTER_VALIDATE_IP)) {
+        $user_ip = GetVars("REMOTE_ADDR", "SERVER");
     }
 
     return $user_ip;


### PR DESCRIPTION
原有的IP地址获取逻辑存在缺陷。当阿里云ESA等CDN传入的请求头类似"x.x.x.x, y.y.y.y"时，会将整个字符串而不是单个IP地址视为一个IP地址，当y.y.y.y作为CDN节点发生变化但真实IP地址没有变化时，由于两者字符串显然不同，将导致验证失败，从而导致用户持续显示“验证码错误”，无法登陆后台页面。

新的数据验证逻辑为，当原始IP地址字符串存在","时，将通过","拆分字符串并取左侧第一个IP地址。同时返回前会对IP地址的有效性进行验证，如果无效则会使用REMOTE_ADDR作为回退备份。

为了避免用户在后台设置时看到的IP地址和实际上程序内部的IP地址不一致，后台展示时改为通过直接调用该函数，以此获取正确的信息。(当然该标头为空时就不显示了)

※：本次问题通过**DeepSeek-V4-Pro**识别，并经过**人工确认**，随后使用**CodeBuddy**对相关逻辑进行了修改。目前已在我自己的网站上进行了测试，没有发生问题。
